### PR TITLE
Custom PID and MotionProfiledPID

### DIFF
--- a/src/main/java/org/chsrobotics/lib/controllers/MotionProfilePID.java
+++ b/src/main/java/org/chsrobotics/lib/controllers/MotionProfilePID.java
@@ -1,0 +1,265 @@
+/**
+Copyright 2022 FRC Team 997
+
+This program is free software: 
+you can redistribute it and/or modify it under the terms of the 
+GNU General Public License as published by the Free Software Foundation, 
+either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with SpartanLib2. 
+If not, see <https://www.gnu.org/licenses/>.
+*/
+package org.chsrobotics.lib.controllers;
+
+import org.chsrobotics.lib.controllers.PID.PIDConstants;
+import org.chsrobotics.lib.trajectory.MotionProfile;
+
+// TODO: Docs
+
+/** */
+public class MotionProfilePID {
+    private final PID controller;
+
+    private final MotionProfile profile;
+
+    private double reference;
+
+    private double lastReference = 0;
+
+    /**
+     * @param constants
+     * @param profile
+     */
+    public MotionProfilePID(PID.PIDConstants constants, MotionProfile profile) {
+        controller = new PID(constants, profile.calculate(0).position);
+        this.profile = profile;
+    }
+
+    /**
+     * @param kP
+     * @param kI
+     * @param kD
+     * @param profile
+     */
+    public MotionProfilePID(double kP, double kI, double kD, MotionProfile profile) {
+        controller = new PID(kP, kI, kD, profile.calculate(0).position);
+        this.profile = profile;
+    }
+
+    /**
+     * Sets the gains of the controller using provided gains.
+     *
+     * @param kP The proportional gain for the controller.
+     * @param kI The integral gain for the controller.
+     * @param kD The derivative gain for the controller.
+     */
+    public void setConstants(double kP, double kI, double kD) {
+        controller.setConstants(kP, kI, kD);
+    }
+
+    /**
+     * Returns the current gains of the controller.
+     *
+     * @return A PIDConstants containing the gains of the controller.
+     */
+    public PIDConstants getConstants() {
+        return controller.getConstants();
+    }
+
+    /**
+     * Sets the gains of the controller using a provided PIDConstants.
+     *
+     * @param constants The PIDConstants containing the gains for the controller.
+     */
+    public void setConstants(PIDConstants constants) {
+        controller.setConstants(constants);
+    }
+
+    /**
+     * Returns the current proportional gain of the controller.
+     *
+     * @return The current kP.
+     */
+    public double getKP() {
+        return controller.getkP();
+    }
+
+    /**
+     * Sets the proportional gain of the controller.
+     *
+     * @param kP The new kP for the controller.
+     */
+    public void setKP(double kP) {
+        controller.setkP(kP);
+    }
+
+    /**
+     * Returns the current integral gain of the controller.
+     *
+     * @return The current kI.
+     */
+    public double getKI() {
+        return controller.getkI();
+    }
+
+    /**
+     * Sets the integral gain of the controller.
+     *
+     * @param kI The new kI for the controller.
+     */
+    public void setKI(double kI) {
+        controller.setkI(kI);
+    }
+
+    /**
+     * Returns the current derivative gain of the controller.
+     *
+     * @return The current kD.
+     */
+    public double getKD() {
+        return controller.getkD();
+    }
+
+    /**
+     * Sets the derivative gain of the controller.
+     *
+     * @param kD The new kD for the controller.
+     */
+    public void setKD(double kD) {
+        controller.setkD(kD);
+    }
+
+    /**
+     * Returns the current setpoint (target) of the controller, as a State with both position and
+     * velocity.
+     *
+     * @param time The time into the profile to sample, above zero in seconds.
+     * @return A State representing the motion profile at that time.
+     */
+    public MotionProfile.State getSetpoint(double time) {
+        return profile.calculate(time);
+    }
+
+    /**
+     * Returns the current setpoint (target) of the controller, as a State with both position and
+     * velocity.
+     *
+     * <p>This uses the last value of {@code reference} given to this class's {@code calculate()}
+     * method.
+     *
+     * @return A State representing the motion profile at that time.
+     */
+    public MotionProfile.State getSetpoint() {
+        return profile.calculate(reference);
+    }
+
+    /**
+     * Returns the accumulated past error in the integral term. Not equal to the output of the I
+     * term: this is not multiplied by the gain.
+     *
+     * @return The integral of error with respect to time from the last reset to now.
+     */
+    public double getIntegralAccumulation() {
+        return controller.getIntegralAccumulation();
+    }
+
+    /** Resets accumulation of past error in the integral term. */
+    public void resetIntegralAccumulation() {
+        controller.resetIntegralAccumulation();
+    }
+
+    /** Resets the previous measurement used for velocity approximation for the derivative term. */
+    public void resetPreviousMeasurement() {
+        controller.resetPreviousMeasurement();
+    }
+
+    /** Resets all references to past states in the controller, effectively restarting it. */
+    public void reset() {
+        controller.reset();
+        lastReference = 0;
+        reference = 0;
+    }
+
+    /**
+     * Sets the maximum position allowed for {@code isFinished()} to return true.
+     *
+     * @param positionTolerance The maximum allowed position error, as a proportion of the setpoint.
+     */
+    public void setSetpointTolerance(double positionTolerance) {
+        controller.setSetpointTolerance(positionTolerance, 0);
+    }
+
+    /**
+     * Returns the maximum allowed position error for {@code isAtSetpoint()} to return true.
+     *
+     * @return The maximum allowed position error, as a proportion of the setpoint.
+     */
+    public double getSetpointPositionTolerance() {
+        return controller.getSetpointPositionTolerance();
+    }
+
+    /**
+     * Returns the last reported measurement given to the controller.
+     *
+     * @return The last reported measurement (0 if none have been given).
+     */
+    public double getCurrentState() {
+        return controller.getCurrentState();
+    }
+
+    /**
+     * Returns an output from the controller, provided a feedback measurement and place into the
+     * MotionProfile to sample.
+     *
+     * <p>For this to work, the value of {@code reference} must increment by the same amount of
+     * times between calls of this.
+     *
+     * @param measurement The value of the measured feedback. If this controller is operating in
+     *     angular mode, this *must* be in radians.
+     * @param reference The time, in seconds greater than zero, to sample into the profile.
+     * @return The sum of the P, I, and D terms.
+     */
+    public double calculate(double measurement, double reference) {
+        controller.setSetpoint(profile.calculate(reference).position);
+        double effort = controller.calculate(measurement, reference - lastReference);
+        lastReference = reference;
+        return effort;
+    }
+
+    /**
+     * Returns an output from the controller, provided a feedback measurement, place into the
+     * MotionProfile, and delta-time.
+     *
+     * @param measurement The value of the measured feedback. If this controller is operating in
+     *     angular mode, this *must* be in radians.
+     * @param reference The time, in seconds greater than zero, to sample into the profile.
+     * @param dt The elapsed time since the last call of any of this class's {@code calculate()}
+     *     methods.
+     * @return The sum of the P, I, and D terms.
+     */
+    public double calculate(double measurement, double reference, double dt) {
+        controller.setSetpoint(profile.calculate(reference).position);
+        double effort = controller.calculate(measurement, dt);
+        lastReference = reference;
+        return effort;
+    }
+
+    /**
+     * Returns whether the controller has reached the position of the setpoint.
+     *
+     * @return Whether the controller is within the minimum position error.
+     */
+    public boolean isAtSetpoint() {
+        return (Math.abs(
+                        profile.calculate(profile.totalTime()).position
+                                - controller.getCurrentState())
+                < Math.abs(
+                        controller.getSetpointPositionTolerance()
+                                * profile.calculate(profile.totalTime()).position));
+    }
+}

--- a/src/main/java/org/chsrobotics/lib/controllers/MotionProfilePID.java
+++ b/src/main/java/org/chsrobotics/lib/controllers/MotionProfilePID.java
@@ -19,9 +19,15 @@ package org.chsrobotics.lib.controllers;
 import org.chsrobotics.lib.controllers.PID.PIDConstants;
 import org.chsrobotics.lib.trajectory.MotionProfile;
 
-// TODO: Docs
-
-/** */
+/**
+ * A PID controller with built-in motion profile following. The setpoint of the controller at a time
+ * is the position value of the motion profile at that time.
+ *
+ * <p>For more information on PID controllers and motion profiles, see {@link
+ * org.chsrobotics.lib.controllers.PID}, {@link org.chsrobotics.lib.trajectory.MotionProfile}, and
+ * {@link org.chsrobotics.lib.trajectory.AsymmetricTrapezoidProfile} and {@link
+ * org.chsrobotics.lib.trajectory.TrapezoidProfile}.
+ */
 public class MotionProfilePID {
     private final PID controller;
 
@@ -32,8 +38,10 @@ public class MotionProfilePID {
     private double lastReference = 0;
 
     /**
-     * @param constants
-     * @param profile
+     * Constructs a MotionProfilePID out of provided PIDConstants and a MotionProfile to follow.
+     *
+     * @param constants The gains of the PID controller.
+     * @param profile The motion profile for the setpoint of the controller to follow.
      */
     public MotionProfilePID(PID.PIDConstants constants, MotionProfile profile) {
         controller = new PID(constants, profile.calculate(0).position);
@@ -41,10 +49,12 @@ public class MotionProfilePID {
     }
 
     /**
-     * @param kP
-     * @param kI
-     * @param kD
-     * @param profile
+     * Constructs a MotionProfilePID out of kP, kI, and kD gains, and a MotionProfile to follow.
+     *
+     * @param kP The Proportional gain of the controller.
+     * @param kI The Integral gain of the controller.
+     * @param kD The Derivative gain of the controller.
+     * @param profile The motion profile for the setpoint of the controller to follow.
      */
     public MotionProfilePID(double kP, double kI, double kD, MotionProfile profile) {
         controller = new PID(kP, kI, kD, profile.calculate(0).position);
@@ -219,8 +229,7 @@ public class MotionProfilePID {
      * <p>For this to work, the value of {@code reference} must increment by the same amount of
      * times between calls of this.
      *
-     * @param measurement The value of the measured feedback. If this controller is operating in
-     *     angular mode, this *must* be in radians.
+     * @param measurement The value of the measured feedback.
      * @param reference The time, in seconds greater than zero, to sample into the profile.
      * @return The sum of the P, I, and D terms.
      */
@@ -235,8 +244,7 @@ public class MotionProfilePID {
      * Returns an output from the controller, provided a feedback measurement, place into the
      * MotionProfile, and delta-time.
      *
-     * @param measurement The value of the measured feedback. If this controller is operating in
-     *     angular mode, this *must* be in radians.
+     * @param measurement The value of the measured feedback.
      * @param reference The time, in seconds greater than zero, to sample into the profile.
      * @param dt The elapsed time since the last call of any of this class's {@code calculate()}
      *     methods.

--- a/src/main/java/org/chsrobotics/lib/controllers/PID.java
+++ b/src/main/java/org/chsrobotics/lib/controllers/PID.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * the past state(s) of a controlled system are leveraged to find the current output.
  *
  * <p>Since the values of the gains are tuned, they and the output are dimensionless. However, the
- * gains should be optimized to output what would be sensible values of other units, such as motor
+ * gains need to be optimized to output what would be sensible values of other units, such as motor
  * controller voltage or duty cycle.
  *
  * <p>The PID controller has three internal components: fittingly, P, I, and D.
@@ -346,8 +346,7 @@ public class PID {
     /**
      * Returns an output from the controller with a given dt.
      *
-     * @param measurement The value of the measured feedback. If this controller is operating in
-     *     angular mode, *must* be in radians.
+     * @param measurement The value of the measured feedback.
      * @param dt The time, in seconds, since the last update of this controller.
      * @return The sum of the P, I, and D terms of the controller.
      */

--- a/src/main/java/org/chsrobotics/lib/controllers/ProportionalIntegralDerivativeController.java
+++ b/src/main/java/org/chsrobotics/lib/controllers/ProportionalIntegralDerivativeController.java
@@ -1,0 +1,388 @@
+/**
+Copyright 2022 FRC Team 997
+
+This program is free software: 
+you can redistribute it and/or modify it under the terms of the 
+GNU General Public License as published by the Free Software Foundation, 
+either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with SpartanLib2. 
+If not, see <https://www.gnu.org/licenses/>.
+*/
+package org.chsrobotics.lib.controllers;
+
+import java.util.Objects;
+import org.chsrobotics.lib.math.UtilityMath;
+
+/**
+ * Implementation of a simple Proportional-Integral-Derivative feedback controller.
+ *
+ * <p>The PID controller is a function with the goal of bringing the difference (or error) between a
+ * setpoint (target) and an actual measurement to zero. It does this using feedback control, where
+ * the past state(s) of a controlled system are leveraged to find the current output.
+ *
+ * <p>Since the values of the gains are tuned, they and the output are dimensionless. However, the
+ * gains can be optimized to output what would be sensible values of other units, such as motor
+ * controller voltage or duty cycle.
+ *
+ * <p>The PID controller has three internal components: fittingly, P, I, and D.
+ *
+ * <p>P, or Proportional, simply consists of multiplication of the error by a constant. This term
+ * does the bulk of lifting in the controller and is usually primarily responsible for the bulk of
+ * the output. In a theoretical world without static friction and motor input limits, it should be
+ * enough to get to the setpoint.
+ *
+ * <p>I, or Integral, consists of the multiplication of the *sum* of past error by a constant. This
+ * past sum should be reset at sensible times to keep it from eccessively accumulating. The Integral
+ * term, as it sums up error over time, is able to turn a small amount of constant error the P term
+ * can't solve (steady-state error) into enough of a control input to get to the setpoint.
+ *
+ * <p>D, Derivative and the final term, consists of the multiplication of the *rate of change* of
+ * the error by a constant. This is useful to prevent the P term of the controller from entering a
+ * series of oscillations where it goes back and forth with high amplitude around the setpoint.
+ *
+ * <p>Methods for tuning the constants of the PID Controller are a matter of opinion, however, the
+ * original author of this doc recommends to start with all constants at 0. Tweak the P term
+ * slightly until you arrive at a situation where the P term rapidly gets to the setpoint without
+ * overshooting. Any steady-state error that is left can be sparingly corrected with the I term. The
+ * D term should be used very carefully as it can cause odd behavior, only save it for times when
+ * it's absolutely imperative to reach the setpoint very quickly and an overly aggressive P term is
+ * needed.
+ */
+public class ProportionalIntegralDerivativeController {
+
+    /** Data class for holding the gains to a ProportionalIntegralDerivativeController. */
+    public static class PIDConstants {
+        private final double kP;
+        private final double kI;
+        private final double kD;
+
+        /**
+         * Constructs a PIDConstants out of provided gains.
+         *
+         * @param kP The proportional gain.
+         * @param kI The integral gain.
+         * @param kD The derivative gain.
+         */
+        public PIDConstants(double kP, double kI, double kD) {
+            this.kP = kP;
+            this.kI = kI;
+            this.kD = kD;
+        }
+
+        /**
+         * Returns the proportional gain.
+         *
+         * @return The kP of the constants.
+         */
+        public double getkP() {
+            return kP;
+        }
+
+        /**
+         * Returns the integral gain.
+         *
+         * @return The kI of the constants.
+         */
+        public double getkI() {
+            return kI;
+        }
+
+        /**
+         * Returns the derivative gain.
+         *
+         * @return The kD of the constants.
+         */
+        public double getkD() {
+            return kD;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            double epsilon = 0.0001;
+            if (other instanceof PIDConstants) {
+                PIDConstants rhs = (PIDConstants) other;
+                return (Math.abs(kP - rhs.kP) < epsilon
+                        && Math.abs(kI - rhs.kI) < epsilon
+                        && Math.abs(kD - rhs.kD) < epsilon);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kP, kI, kD);
+        }
+
+        @Override
+        public String toString() {
+            return ("PIDConstants: " + kP + ", " + kI + ", " + kD);
+        }
+    }
+
+    private double kP;
+    private double kI;
+    private double kD;
+
+    private double lastMeasurement = 0;
+    private double integralAccumulation = 0;
+
+    private double setpoint;
+
+    private double velocity = 0;
+
+    private double positionTolerance = 0.02;
+    private double velocityTolerance = 0.02;
+
+    private final boolean isAngular;
+
+    /**
+     * Constructs a ProportionalIntegralDerivativeController with given gains.
+     *
+     * @param kP The initial proportional gain of the controller.
+     * @param kI The initial integral gain of the controller.
+     * @param kD The initial derivative gain of the controller.
+     * @param initialSetpoint The initial setpoint (or target) of the controller.
+     * @param isAngular If true, the controller will automatically seek the shortest angle to
+     *     travel. However, if using this, values for the {@code measurement} and {@code setpoint}
+     *     *must* be in radians.
+     */
+    public ProportionalIntegralDerivativeController(
+            double kP, double kI, double kD, double initialSetpoint, boolean isAngular) {
+        this.kP = kP;
+        this.kI = kI;
+        this.kD = kD;
+        this.isAngular = isAngular;
+        setpoint = isAngular ? UtilityMath.normalizeAngleRadians(initialSetpoint) : initialSetpoint;
+    }
+
+    /**
+     * Constructs a ProportionalIntegralDerivativeController with a given PIDConstants.
+     *
+     * @param constants The PIDConstants containing the gains for this controller.
+     * @param initialSetpoint The initial setpoint (or target) of the controller.
+     * @param isAngular If true, the controller will automatically seek the shortest angle to
+     *     travel. However, if using this, values for the {@code measurement} and {@code setpoint}
+     *     *must* be in radians.
+     */
+    public ProportionalIntegralDerivativeController(
+            PIDConstants constants, double initialSetpoint, boolean isAngular) {
+        this(constants.getkP(), constants.getkI(), constants.getkD(), initialSetpoint, isAngular);
+    }
+
+    /**
+     * Sets the gains of the controller using provided gains.
+     *
+     * @param kP The proportional gain for the controller.
+     * @param kI The integral gain for the controller.
+     * @param kD The derivative gain for the controller.
+     */
+    public void setConstants(double kP, double kI, double kD) {
+        this.kP = kP;
+        this.kI = kI;
+        this.kD = kD;
+    }
+
+    /**
+     * Sets the gains of the controller using a provided PIDConstants.
+     *
+     * @param constants The PIDConstants containing the gains for the controller.
+     */
+    public void setConstants(PIDConstants constants) {
+        this.kP = constants.getkP();
+        this.kI = constants.getkI();
+        this.kD = constants.getkD();
+    }
+
+    /**
+     * Returns the current gains of the controller.
+     *
+     * @return A PIDConstants containing the gains of the controller.
+     */
+    public PIDConstants getConstants() {
+        return new PIDConstants(kP, kI, kD);
+    }
+
+    /**
+     * Returns the current proportional gain of the controller.
+     *
+     * @return The current kP.
+     */
+    public double getkP() {
+        return kP;
+    }
+
+    /**
+     * Sets the proportional gain of the controller.
+     *
+     * @param kP The new kP for the controller.
+     */
+    public void setkP(double kP) {
+        this.kP = kP;
+    }
+
+    /**
+     * Returns the current integral gain of the controller.
+     *
+     * @return The current kI.
+     */
+    public double getkI() {
+        return kI;
+    }
+
+    /**
+     * Sets the integral gain of the controller.
+     *
+     * @param kI The new kI for the controller.
+     */
+    public void setkI(double kI) {
+        this.kI = kI;
+    }
+
+    /**
+     * Returns the current derivative gain of the controller.
+     *
+     * @return The current kD.
+     */
+    public double getkD() {
+        return kD;
+    }
+
+    /**
+     * Sets the derivative gain of the controller.
+     *
+     * @param kD The new kD for the controller.
+     */
+    public void setkD(double kD) {
+        this.kD = kD;
+    }
+
+    /**
+     * Sets the setpoint (target) of the controller. If this controller is angular, this value
+     * *must* be in radians.
+     *
+     * @param value The new target of the controller.
+     */
+    public void setSetpoint(double value) {
+        setpoint = isAngular ? UtilityMath.normalizeAngleRadians(value) : value;
+    }
+
+    /**
+     * Returns the current setpoint (target) of the controller.
+     *
+     * @return The current setpoint.
+     */
+    public double getSetpoint() {
+        return setpoint;
+    }
+
+    /** Resets accumulation of past error in the integral term. */
+    public void resetIntegralAccumulation() {
+        integralAccumulation = 0;
+    }
+
+    /** Resets the previous measurement used for velocity approximation for the derivative term. */
+    public void resetPreviousMeasurement() {
+        lastMeasurement = 0;
+    }
+
+    /** Resets all references to past states in the controller, effectively restarting it. */
+    public void reset() {
+        resetIntegralAccumulation();
+        resetPreviousMeasurement();
+    }
+
+    /**
+     * Returns true if the controller is angular (if will seek the shortest angle to a target).
+     *
+     * @return Whether the controller will see the setpoints 2pi and 0 as the same.
+     */
+    public boolean isAngular() {
+        return isAngular;
+    }
+
+    /**
+     * Sets the maximum error of both position and velocity allowed for {@code isFinished()} to
+     * return true.
+     *
+     * @param positionTolerance The maximum allowed position error, as a proportion of the setpoint.
+     * @param velocityTolerance The maximum allowed absolute velocity per second, as a proportion of
+     *     the setpoint / second.
+     */
+    public void setSetpointTolerance(double positionTolerance, double velocityTolerance) {
+        this.positionTolerance = positionTolerance;
+        this.velocityTolerance = velocityTolerance;
+    }
+
+    /**
+     * Returns the maximum allowed position error for {@code isFinished()} to return true.
+     *
+     * @return The maximum allowed position error, as a proportion of the setpoint.
+     */
+    public double getSetpointPositionTolerance() {
+        return positionTolerance;
+    }
+
+    /**
+     * Returns the maximum allowed velocity error for {@code isFinished()} to return true.
+     *
+     * @return The maximum allowed absolute velocity per second, as a proportion of the setpoint.
+     */
+    public double getSetpointVelocityTolerance() {
+        return velocityTolerance;
+    }
+
+    /**
+     * Returns an output from the controller with a given dt.
+     *
+     * @param measurement The value of the measured feedback. If this controller is operating in
+     *     angular mode, *must* be in radians.
+     * @param dt The time, in seconds, since the last update of this controller.
+     * @return The sum of the P, I, and D terms of the controller.
+     */
+    public double calculate(double measurement, double dt) {
+        double shortestPathMeasurement =
+                UtilityMath.smallestAngleRadiansBetween(measurement, setpoint);
+
+        integralAccumulation += dt * (setpoint - shortestPathMeasurement);
+        velocity = ((shortestPathMeasurement - lastMeasurement) / dt);
+
+        double p = kP * (setpoint - shortestPathMeasurement);
+        double i = kI * integralAccumulation;
+        double d = kD * velocity;
+
+        lastMeasurement = shortestPathMeasurement;
+
+        return p + i + d;
+    }
+
+    /**
+     * Returns an output from the controller with the default robot loop time.
+     *
+     * <p>This must be called once every robot loop to be consistent.
+     *
+     * @param measurement The value of the measured feedback. If this controller is operating in
+     *     angular mode, *must* be in radians.
+     * @return The sum of the P, I, and D terms of the controller.
+     */
+    public double calculate(double measurement) {
+        return calculate(measurement, 0.02);
+    }
+
+    /**
+     * Returns whether the controller is at the setpoint and within tolerances specified by {@code
+     * setSetpointTolerance()}.
+     *
+     * @return Whether the controller is within the maximum errors.
+     */
+    public boolean isAtSetpoint() {
+        return (Math.abs(setpoint - lastMeasurement) < (positionTolerance * setpoint)
+                && Math.abs(velocity) < (velocityTolerance * setpoint));
+    }
+}

--- a/src/main/java/org/chsrobotics/lib/math/UtilityMath.java
+++ b/src/main/java/org/chsrobotics/lib/math/UtilityMath.java
@@ -50,8 +50,8 @@ public class UtilityMath {
      *
      * @param angleA The first angle, in radians.
      * @param angleB The second angle, in raidans.
-     * @return A signed angle in radians representing the smallest counterclockwise angle between
-     *     angles a and b.
+     * @return A signed angle in radians representing the smallest (positive is counterclockwise)
+     *     angle between angles a and b.
      */
     public static double smallestAngleRadiansBetween(double angleA, double angleB) {
         double normA = UtilityMath.normalizeAngleRadians(angleA);
@@ -68,8 +68,8 @@ public class UtilityMath {
      *
      * @param angleA The first angle, in degrees.
      * @param angleB The second angle, in degrees.
-     * @return A signed angle in degrees representing the smallest counterclockwise angle between
-     *     angles a and b.
+     * @return A signed angle in degrees representing the smallest (positive is counterclockwise)
+     *     angle between angles a and b.
      */
     public static double smallestAngleDegreesBetween(double angleA, double angleB) {
         double normA = UtilityMath.normalizeAngleDegrees(angleA);

--- a/src/main/java/org/chsrobotics/lib/math/UtilityMath.java
+++ b/src/main/java/org/chsrobotics/lib/math/UtilityMath.java
@@ -44,6 +44,42 @@ public class UtilityMath {
     }
 
     /**
+     * Returns the angle in radians between two other angles with the smallest absolute value.
+     *
+     * <p>A negative number indicates a clockwise rotation from angle a to angle b.
+     *
+     * @param angleA The first angle, in radians.
+     * @param angleB The second angle, in raidans.
+     * @return A signed angle in radians representing the smallest counterclockwise angle between
+     *     angles a and b.
+     */
+    public static double smallestAngleRadiansBetween(double angleA, double angleB) {
+        double normA = UtilityMath.normalizeAngleRadians(angleA);
+        double normB = UtilityMath.normalizeAngleRadians(angleB);
+
+        double diff = (normB - normA + Math.PI) % (2 * Math.PI) - Math.PI;
+        return (diff < -Math.PI) ? diff + (2 * Math.PI) : diff;
+    }
+
+    /**
+     * Returns the angle in degrees between two other angles with the smallest absolute value.
+     *
+     * <p>A negative number indicates a clockwise rotation from angle a to angle b.
+     *
+     * @param angleA The first angle, in degrees.
+     * @param angleB The second angle, in degrees.
+     * @return A signed angle in degrees representing the smallest counterclockwise angle between
+     *     angles a and b.
+     */
+    public static double smallestAngleDegreesBetween(double angleA, double angleB) {
+        double normA = UtilityMath.normalizeAngleDegrees(angleA);
+        double normB = UtilityMath.normalizeAngleDegrees(angleB);
+
+        double diff = (normB - normA + 180) % 360 - 180;
+        return (diff < -180) ? diff + 360 : diff;
+    }
+
+    /**
      * Interpolates a value between two points.
      *
      * <p>For more complex, multi-point interpolation, use the {@link MultiPointInterpolator} class.

--- a/src/main/java/org/chsrobotics/lib/trajectory/MotionProfile.java
+++ b/src/main/java/org/chsrobotics/lib/trajectory/MotionProfile.java
@@ -156,8 +156,8 @@ public class MotionProfile {
      * @return The position and velocity of the profile at that time.
      */
     public State calculate(double time) {
-        if (time < 0) {
-            return new State(0, 0);
+        if (time <= 0) {
+            return initialState;
         }
         double position = initialState.position;
         for (ProfilePhase phase : phases) {

--- a/src/test/java/org/chsrobotics/lib/controllers/MotionProfilePIDTests.java
+++ b/src/test/java/org/chsrobotics/lib/controllers/MotionProfilePIDTests.java
@@ -63,6 +63,6 @@ public class MotionProfilePIDTests {
         assertEquals(0, controller.calculate(0, 0), epsilon);
         assertEquals(0.5, controller.calculate(0, 0.5), epsilon);
         assertEquals(1.5, controller.calculate(0, 1), epsilon);
-        // TODO: more D tests
+        assertEquals(1, controller.calculate(1, 2), epsilon);
     }
 }

--- a/src/test/java/org/chsrobotics/lib/controllers/MotionProfilePIDTests.java
+++ b/src/test/java/org/chsrobotics/lib/controllers/MotionProfilePIDTests.java
@@ -1,0 +1,68 @@
+/**
+Copyright 2022 FRC Team 997
+
+This program is free software: 
+you can redistribute it and/or modify it under the terms of the 
+GNU General Public License as published by the Free Software Foundation, 
+either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with SpartanLib2. 
+If not, see <https://www.gnu.org/licenses/>.
+*/
+package org.chsrobotics.lib.controllers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.chsrobotics.lib.controllers.PID.PIDConstants;
+import org.chsrobotics.lib.trajectory.AsymmetricTrapezoidProfile;
+import org.chsrobotics.lib.trajectory.AsymmetricTrapezoidProfile.Constraints;
+import org.chsrobotics.lib.trajectory.MotionProfile;
+import org.chsrobotics.lib.trajectory.MotionProfile.State;
+import org.chsrobotics.lib.trajectory.ProfilePhase;
+import org.junit.Test;
+
+/** Tests for the MotionProfilePID. */
+public class MotionProfilePIDTests {
+    private final double epsilon = 0.0001;
+
+    @Test
+    public void MotionProfilePIDPControllerWorks() {
+        AsymmetricTrapezoidProfile profile =
+                new AsymmetricTrapezoidProfile(new Constraints(1, 1, 1), new State(4, 0));
+        MotionProfilePID controller = new MotionProfilePID(new PIDConstants(1, 0, 0), profile);
+
+        assertEquals(0, controller.calculate(0, 0), epsilon);
+        assertEquals(0.025, controller.calculate(0.1, 0.5), epsilon);
+        assertEquals(-0.1, controller.calculate(0.6, 1), epsilon);
+    }
+
+    @Test
+    public void MotionProfilePIDIntegralAccumulationWorks() {
+        AsymmetricTrapezoidProfile profile =
+                new AsymmetricTrapezoidProfile(new Constraints(5, 1, 1), new State(10, 0));
+        MotionProfilePID controller = new MotionProfilePID(0, 0.5, 0, profile);
+
+        controller.calculate(0, 0);
+        controller.calculate(0.6, 1);
+        controller.calculate(1.5, 2);
+        controller.calculate(5.2, 3);
+
+        assertEquals(-0.15, controller.calculate(0, 3), epsilon);
+    }
+
+    @Test
+    public void MotionProfilePIDDerivativeWorks() {
+        MotionProfile profile = new MotionProfile(new ProfilePhase(1, 0, 10));
+        MotionProfilePID controller = new MotionProfilePID(0, 0, 2, profile);
+
+        assertEquals(0, controller.calculate(0, 0), epsilon);
+        assertEquals(0.5, controller.calculate(0, 0.5), epsilon);
+        assertEquals(1.5, controller.calculate(0, 1), epsilon);
+        // TODO: more D tests
+    }
+}

--- a/src/test/java/org/chsrobotics/lib/controllers/PIDTests.java
+++ b/src/test/java/org/chsrobotics/lib/controllers/PIDTests.java
@@ -1,0 +1,81 @@
+/**
+Copyright 2022 FRC Team 997
+
+This program is free software: 
+you can redistribute it and/or modify it under the terms of the 
+GNU General Public License as published by the Free Software Foundation, 
+either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with SpartanLib2. 
+If not, see <https://www.gnu.org/licenses/>.
+*/
+package org.chsrobotics.lib.controllers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** Tests for the SpartanLib PID controller. */
+public class PIDTests {
+    private final double epsilon = 0.0001;
+
+    @Test
+    public void PIDProportionalControllerWorks() {
+        PID controller = new PID(1, 0, 0, 0);
+        controller.setSetpoint(5);
+        assertEquals(5, controller.calculate(0), epsilon);
+        assertEquals(2.5, controller.calculate(2.5), epsilon);
+        assertEquals(0.1, controller.calculate(4.9), epsilon);
+        assertEquals(-0.5, controller.calculate(5.5), epsilon);
+    }
+
+    @Test
+    public void PIDIntegralControllerWorks() {
+        PID controller = new PID(0, 0.1, 0, 10);
+        assertEquals(1, controller.calculate(0, 1), epsilon);
+        assertEquals(1.9, controller.calculate(1, 1), epsilon);
+        assertEquals(2.5, controller.calculate(4, 1), epsilon);
+
+        controller.resetIntegralAccumulation();
+        assertEquals(0, controller.getIntegralAccumulation(), 0);
+
+        controller.setkI(2.5);
+        assertEquals(0.5, controller.calculate(0), epsilon);
+        assertEquals(0.75, controller.calculate(5), epsilon);
+        assertEquals(0.5, controller.calculate(15), epsilon);
+    }
+
+    @Test
+    public void PIDDerivativeControllerWorks() {
+        PID controller = new PID(0, 0, 0.1, 10);
+        assertEquals(0, controller.calculate(0, 1), epsilon);
+        assertEquals(-0.5, controller.calculate(5, 1), epsilon);
+        assertEquals(0.1, controller.calculate(4, 1), epsilon);
+        assertEquals(-0.8, controller.calculate(12, 1), epsilon);
+
+        controller.resetPreviousMeasurement();
+        controller.setkD(2);
+        assertEquals(-100, controller.calculate(1), epsilon);
+        assertEquals(0, controller.calculate(1), epsilon);
+    }
+
+    @Test
+    public void PIDAtSetpointWorks() {
+        PID controller = new PID(0, 0, 0, 100);
+
+        controller.calculate(98);
+        assertEquals(false, controller.isAtSetpoint());
+        controller.calculate(99, 1);
+        assertEquals(true, controller.isAtSetpoint());
+
+        controller.setSetpointTolerance(0.01, 0.01);
+        assertEquals(false, controller.isAtSetpoint());
+        controller.calculate(99.5, 1);
+        assertEquals(true, controller.isAtSetpoint());
+    }
+}

--- a/src/test/java/org/chsrobotics/lib/math/UtilityMathTests.java
+++ b/src/test/java/org/chsrobotics/lib/math/UtilityMathTests.java
@@ -70,6 +70,41 @@ public class UtilityMathTests {
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // smallestAngleRadiansBetween
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    @Test
+    public void UtilityMathSmallestAngleRadiansBetweenWorksProperly() {
+        assertEquals(0, UtilityMath.smallestAngleRadiansBetween(2 * Math.PI, 0), epsilon);
+        assertEquals(
+                -0.5 * Math.PI,
+                UtilityMath.smallestAngleRadiansBetween(1.5 * Math.PI, Math.PI),
+                epsilon);
+        assertEquals(
+                0.25 * Math.PI,
+                UtilityMath.smallestAngleRadiansBetween(1.75 * Math.PI, 2 * Math.PI),
+                epsilon);
+        assertEquals(-Math.PI, UtilityMath.smallestAngleRadiansBetween(Math.PI, 0), epsilon);
+        assertEquals(-Math.PI, UtilityMath.smallestAngleRadiansBetween(-3 * Math.PI, 0), epsilon);
+        assertEquals(
+                0.25 * Math.PI,
+                UtilityMath.smallestAngleRadiansBetween(-0.125 * Math.PI, 0.125 * Math.PI),
+                epsilon);
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // smallestAngleDegreesBetween
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    @Test
+    public void UtilityMathSmallestAngleDegreesBetweenWorksProperly() {
+        assertEquals(0, UtilityMath.smallestAngleDegreesBetween(360, 0), epsilon);
+        assertEquals(-90, UtilityMath.smallestAngleDegreesBetween(270, 180), epsilon);
+        assertEquals(45, UtilityMath.smallestAngleDegreesBetween(315, 360), epsilon);
+        assertEquals(-180, UtilityMath.smallestAngleDegreesBetween(180, 0), epsilon);
+        assertEquals(-180, UtilityMath.smallestAngleDegreesBetween(-540, 0), epsilon);
+        assertEquals(45, UtilityMath.smallestAngleDegreesBetween(-22.5, 22.5), epsilon);
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // simpleLinearInterpolation
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     @Test


### PR DESCRIPTION
The WPILib PID controllers can't follow our custom motion profiles-- so I made our own.

These controllers come with a few improvements over the WPILib controllers, specifically giving greater information about and control over the integral accumulation of the controller, and _properly_ integrating and deriving for the I and D terms (they don't multiply / divide by dt as far as I know).